### PR TITLE
React 16 Support + Fix NPM links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "lit": {
       "version": "2.0.0-rc.1",
@@ -84,6 +85,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -91,7 +93,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "path-data-parser": {
       "version": "0.1.0",
@@ -116,6 +119,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rough-stuff/react-wired-elements.git"
+    "url": "git+https://github.com/rough-stuff/wired-elements-react.git"
   },
   "keywords": [
     "wired",
@@ -21,15 +21,18 @@
   "author": "Preet Shihn",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/rough-stuff/react-wired-elements/issues"
+    "url": "https://github.com/rough-stuff/wired-elements-react/issues"
   },
-  "homepage": "https://github.com/rough-stuff/react-wired-elements#readme",
+  "homepage": "https://github.com/rough-stuff/wired-elements-react#readme",
+  "peerDependencies": {
+    "react": ">=16 <18"
+  },
   "dependencies": {
     "@lit-labs/react": "^1.0.0-rc.1",
-    "react": "^17.0.2",
     "wired-elements": "^3.0.0-rc.6"
   },
   "devDependencies": {
-    "@types/react": "^17.0.3"
+    "@types/react": "^17.0.3",
+    "react": "^17.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.5",
   "description": "React wrappers for wired-elements",
   "type": "module",
+  "sideEffects": false,
   "main": "lib/WiredElements.js",
   "module": "lib/WiredElements.js",
   "types": "lib/WiredElements.d.ts",


### PR DESCRIPTION
### Move `react` to peerDependency
Specifying `react` as a dependency can cause multiple versions of React to be present in a single consumer build if there is a semver mismatch and `npm`/`yarn` is unable to dedupe.

### Support `react@16`
AFAIK this library works just fine on `react@16`, so specifying a semver range that includes 16.

### Fix npm links
The links specified in `package.json` were pointing to a non-existing repository on https://www.npmjs.com/package/wired-elements-react

### Add `sideEffects`
Specifying `"sideEffects": false` in the `package.json` will enable bundlers like webpack to tree-shake the module.